### PR TITLE
fix(backend): config file wasnt copied

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,9 +13,10 @@ RUN apt-get update && apt-get install -y curl
 WORKDIR /app
 
 COPY --from=builder /app/target/release/hacktoberfest hacktoberfest
+COPY --from=builder /app/target.yml target.yml
 
 EXPOSE 8080
 
-ENV CONFIG_PATH=target.yml
+ENV CONFIG_PATH=/app/target.yml
 
 CMD ["/app/hacktoberfest"]


### PR DESCRIPTION
fixes custom repositories that are defined on target.yml, yet didn't show up on the `/repo` endpoint