### PR TITLE
fix(frontend): add flex-wrap to language logo

### DIFF
--- a/frontend/src/components/repository-card/repository-card.css
+++ b/frontend/src/components/repository-card/repository-card.css
@@ -52,6 +52,7 @@
 
 .repository-card__right-content {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
 }


### PR DESCRIPTION
Add flex-wrap css to language logo in repository-card, so no more overflow on mobile.
For issue #59 

### before
![Screenshot 2022-10-05 at 11-02-13 Hacktoberfest Teknologi Umum](https://user-images.githubusercontent.com/36098718/193979011-a4a4bf5f-e765-4eac-8846-a049879c806c.png)

### after
![Screenshot 2022-10-05 at 11-02-52 Hacktoberfest Teknologi Umum](https://user-images.githubusercontent.com/36098718/193979041-2c21421e-8318-469a-938c-53b5df1524b0.png)
