### PR TITLE
fix(frontend): title overflow on mobile

### DIFF
--- a/frontend/src/components/header/header.css
+++ b/frontend/src/components/header/header.css
@@ -4,7 +4,6 @@
 }
 
 .header__text {
-  white-space: nowrap;
   text-align: center;
   font-size: clamp(2rem, 1rem + 4vw, 4.8rem);
   font-family: "Press Start 2P", sans-serif;

--- a/frontend/src/components/repository-card/repository-card.css
+++ b/frontend/src/components/repository-card/repository-card.css
@@ -35,6 +35,7 @@
 .repository-card__title {
   font-size: 2.4rem;
   font-weight: 600;
+  word-break: break-all;
   text-decoration: none;
   color: #efefef;
   line-height: 1em;


### PR DESCRIPTION
## Resolve on issue #61 

I fixed title overflow on mobile both for Header title and Repository card title

## Header title
### before
![Screenshot 2022-10-05 at 18-50-12 Hacktoberfest Teknologi Umum](https://user-images.githubusercontent.com/36098718/194056195-be941a5a-e05a-4279-8202-1de1a112985b.png)
### after
![Screenshot 2022-10-05 at 18-50-38 Hacktoberfest Teknologi Umum](https://user-images.githubusercontent.com/36098718/194056237-e7481a34-0b8e-45d7-982e-b556e5640e7f.png)

## Repository card title
### before
![Screenshot 2022-10-05 at 18-51-06 Hacktoberfest Teknologi Umum](https://user-images.githubusercontent.com/36098718/194056397-427aaf68-f999-48b8-98d0-9f9a3c9a5562.png)
### after
![Screenshot 2022-10-05 at 18-51-46 Hacktoberfest Teknologi Umum](https://user-images.githubusercontent.com/36098718/194056444-b92cb74d-cc8c-4bf1-aa3f-6e540d4a5bf8.png)

